### PR TITLE
Fix Makefile to use default behavior on shell selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SHELL := $(shell env | grep SHELL= | cut -d '=' -f '2' )
-
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python3 --version 2>&1)))
 python_version_minor := $(word 2,${python_version_full})
 


### PR DESCRIPTION
Some of us have a variable called RBENV_SHELL that is matched by the current grep.
This PR fixes this issue using a simpler way to get the default shell: just using rely on makefile defaults use to $SHELL variable (cfr [GNU make doc](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html)).